### PR TITLE
fixed domain in account activation and reset password links

### DIFF
--- a/user_api/const.py
+++ b/user_api/const.py
@@ -1,10 +1,14 @@
 from django.contrib.sites.shortcuts import get_current_site
 import urllib.parse
-from rest_framework.status import (
-    HTTP_500_INTERNAL_SERVER_ERROR,
-    HTTP_401_UNAUTHORIZED,
-    HTTP_200_OK
-)
+import os
+
+
+def get_link_domain():
+    if os.environ.get("ENV") == "production":
+        return "https://ihr.iijlab.net/ihr"
+    else:
+        return "http://localhost:8080"
+
 
 class ConfirmationEmail:
     def __init__(self, email, token, password_change=False):
@@ -20,7 +24,7 @@ Confirm your email address to get started with Internet Health Report
 Confirmed that {self.email} is your email address to access to the personalization panel.
 
 Confirm email address
-[http://localhost:8080/en-us/account_activation?token={self.token}{self.query}]
+[{get_link_domain()}/en-us/account_activation?token={self.token}{self.query}]
 
 If you haven’t requested this email, you can safely ignore it.
 '''
@@ -28,6 +32,7 @@ If you haven’t requested this email, you can safely ignore it.
     @property
     def HTML(self):
         return '''HTML VERSION'''
+
 
 class ResetPasswordEmail:
     def __init__(self, email, token):
@@ -41,7 +46,7 @@ You request a email reset at Internet Health Report
 
 click on the link to reset your password.
 
-[http://localhost:8080/en-us/reset_password?token={self.token}]
+[{get_link_domain()}/en-us/reset_password?token={self.token}
 
 If you haven’t requested this email, you can safely ignore it.
 '''
@@ -54,13 +59,14 @@ If you haven’t requested this email, you can safely ignore it.
 class StrErrors:
     OK = "ok"
     GENERIC = "Try again later. If the error persist please contact the administrator"
-    WRONG_DATA= "check your data e try again"
+    WRONG_DATA = "check your data e try again"
     DUPLICATED = "duplicated email"
     INVALID = "invalid"
     TRY_AGAIN = "try again"
     RECAPTCHA_MISCONFIGURATION = "google_token_verification misconfiguration"
     ASN_DOESNOT_EXIST = "one of the as you sent is not in our server"
     ALREADY_VALIDATED = "this user is already validated"
+
     class INPUT:
         ADD_MONITORING = "you must provide a non empty array of (asn, alertLevel)"
         DUPLICATED = "your input contains duplicated data. Please check and try again"


### PR DESCRIPTION
Account activation and reset password emails contain localhost links on production. This update will use `https://ihr.iijlab.net/ihr` if `os.environ.get("ENV") == "production"`.

![image](https://user-images.githubusercontent.com/63334359/228732623-3b62aada-f241-45ec-9bc9-0c1b46353b1a.png)
