### PR TITLE
Specified  django version and relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install django:
 ```zsh
 cd ihr
 . bin/activate
-pip install django
+pip install django==2.2.27
 ```
 
 Create a new django project:
@@ -93,7 +93,7 @@ Remove migration files and create tables: (TODO move production migration files 
 find . -path "*/migrations/*.py" -not -name "__init__.py" -delete
 find . -path "*/migrations/*.pyc"  -delete
 ./manage.py makemigrations
-manage.py migrate
+./manage.py migrate
 ```
 
 Start django:


### PR DESCRIPTION
Fixes #55
Fixes ihr-django installation guide. By specifying django version to 2.2.27 and correcting relative path to make migrations
